### PR TITLE
[SDK1.14]: Add changes to enable the LLM on 1.14 SDK

### DIFF
--- a/QEfficient/cloud/compile.py
+++ b/QEfficient/cloud/compile.py
@@ -5,9 +5,10 @@
 #
 # -----------------------------------------------------------------------------
 
-import os
 import argparse
 import json
+import os
+import pathlib
 from typing import List
 
 from QEfficient.exporter.export_utils import compile_kv_model_on_cloud_ai_100
@@ -62,10 +63,14 @@ def main(
         batch_size=batch_size, prompt_len=prompt_len, ctx_len=ctx_len, path=specialization_json_path
     )
     custom_io_file_path = os.path.join(os.path.dirname(onnx_path), "custom_io.yaml")
-    
+
     if not os.path.isfile(custom_io_file_path):
         raise FileNotFoundError(f"file {custom_io_file_path} needs to exist in the same directory as onnx model files.")
 
+    # todo: vbaddi: Identify better way to get the config path. fix it in tag/1.14 in main repo.
+    custom_rms_op_config_path = os.path.join(
+        pathlib.Path(onnx_path).parents[4], "QEfficient/customop/custom_rms_op_config.yaml"
+    )
     _, qpc_path = compile_kv_model_on_cloud_ai_100(
         onnx_path=onnx_path,
         specializations_json=specialization_json_path,
@@ -76,6 +81,7 @@ def main(
         aic_enable_depth_first=aic_enable_depth_first,
         mos=mos,
         device_group=device_group,
+        config=custom_rms_op_config_path,
     )
 
     logger.info(f"Compiled QPC files can be found here: {qpc_path}")
@@ -120,7 +126,8 @@ if __name__ == "__main__":
         help="Cloud AI 100 device ids (comma-separated) e.g. [0] ",
     )
     parser.add_argument(
-        "--aic_enable_depth_first", "--aic-enable-depth-first",
+        "--aic_enable_depth_first",
+        "--aic-enable-depth-first",
         action="store_true",
         help="If passed, this option will be enabled during compilation, disabled by default",
     )

--- a/QEfficient/customop/CustomRMSNorm/src/customrmsnorm_functions.cpp
+++ b/QEfficient/customop/CustomRMSNorm/src/customrmsnorm_functions.cpp
@@ -19,7 +19,7 @@ bool customOpVerify(const CustomOpProperties *const opProp) {
     return false;
   auto &param0 = opProp->params[0];
   // Check params names are valid.
-  if (strcmp(param0.name, "eps"))
+  if (strcmp(param0.name, "epsilon"))
     return false;
   // Op must have only 2 input and 1 output.
   if (opProp->inputs.size() != 2 || opProp->outputs.size() != 1)

--- a/QEfficient/customop/__init__.py
+++ b/QEfficient/customop/__init__.py
@@ -16,7 +16,7 @@ from onnxscript.onnx_opset import opset13 as op
 from torch import nn
 
 opset_version = 13
-custom_opset = onnxscript.values.Opset(domain="com.qti.aisw.onnx", version=1)
+custom_opset = onnxscript.values.Opset(domain="QAic::QEffCustomRMSNorm", version=1)
 
 
 # Version 1

--- a/QEfficient/customop/custom_rms_op_config.yaml
+++ b/QEfficient/customop/custom_rms_op_config.yaml
@@ -8,7 +8,7 @@
 ---
 version: 5.0.0
 CustomOps:
-  - type: CustomRMSNorm
+  - type: QEffCustomRMSNorm::CustomRMSNorm
     package: QAic
     inputs:
     - name: hidden_states
@@ -16,13 +16,13 @@ CustomOps:
     - name: weight
       maxDims: 1
     parameters:
-    - name: eps
+    - name: epsilon
       dataType: float
       scalar: true
     outputs:
     - name: output
       maxDims: 3
-    functionsLibrary: CustomRMSNorm/src/customrmsnorm_lib.so
+    functionsLibrary: CustomRMSNorm/src/libcustomrmsnorm_lib.so
     implementations:
     - backend: AIC
       type: CustomRMSNormAIC

--- a/QEfficient/exporter/export_utils.py
+++ b/QEfficient/exporter/export_utils.py
@@ -19,6 +19,8 @@ import onnxruntime
 import torch
 from onnx import external_data_helper, numpy_helper
 
+from QEfficient.utils.logging_utils import logger
+
 
 def export_onnx(
     pt_model: torch.nn.Module,
@@ -80,7 +82,7 @@ def export_onnx(
             output_names=output_names,
             dynamic_axes=dynamic_axes,
             opset_version=13,
-            custom_opsets={"com.qti.aisw.onnx": 1},
+            custom_opsets={"QAic::QEffCustomRMSNorm": 1},
         )
     except Exception as e:
         error("Exporting to ONNX failed. {}".format(e))
@@ -236,6 +238,11 @@ def fix_onnx_fp16(
 
         # Check if the FP16-fixed model can be used for FP32
         close_outputs = []
+        model = onnx.load(os.path.join(gen_models_path, f"{model_base_name}.onnx"), load_external_data=False)
+        for node in model.graph.node:
+            if node.op_type == "QEffCustomRMSNorm::CustomRMSNorm":
+                return model_base_name
+
         _, ort_outputs_fixed = run_model_on_ort(
             os.path.join(gen_models_path, f"{model_base_name}.onnx"),
             inputs,
@@ -293,6 +300,12 @@ def run_model_on_ort(
     pt_outputs: Dict[str, torch.Tensor],
     dtype: bool = True,
 ) -> Tuple[List[str], List[np.ndarray]]:
+    model = onnx.load(onnx_path, load_external_data=False)
+    for node in model.graph.node:
+        if node.op_type == "QEffCustomRMSNorm::CustomRMSNorm":
+            input_names = [x.name for x in model.graph.input]
+            logger.warning(f"Onnxruntime execution is skipped due to customop {node.op_type}")
+            return input_names, None
     try:
         if dtype:
             info_string = "fp32"
@@ -397,6 +410,13 @@ def compile_kv_model_on_cloud_ai_100(
     ]
     if mxfp6:
         command.append("-mxfp6-matmul")
+    model = onnx.load(onnx_path, load_external_data=False)
+    for node in model.graph.node:
+        if node.op_type == "QEffCustomRMSNorm::CustomRMSNorm":
+            logger.warning(f"Cloud AI 100 execution is with regular customop setup: {node.op_type}")
+            config = kwargs["config"]
+            command.append(f"-register-custom-op={config}")
+            break
     if mos > 0:
         command.append(f"-mos={mos}")
     if aic_enable_depth_first:


### PR DESCRIPTION
Couple of data points on this PR:

- Support to the run the LLMs on the 1.14 SDK.
- Uses the regular CustomOp path, pls refer the customop readme to generate the shared library required to execute the model with regular customop on cloud ai 100.
- There will be no change in the `infer` API usage.
- The Onnxruntime execution will be skipped, due to regular customop. Since there is no implementation for customop in Onnxrt via qeff.
- **Sample test command:** `python -m QEfficient.cloud.infer --model-name meta-llama/Llama-2-7b-hf  --cache-dir models --batch-size 1 --prompt-len 32 --ctx-len 128 --mxfp6 --num-cores 16 --device-group "[0]" --prompt "Top one must do thing in Bengaluru" --aic_enable_depth_first --mos 1 --hf-token ***********`